### PR TITLE
Umlaute nun richtig im XML

### DIFF
--- a/R/stata2ddi.R
+++ b/R/stata2ddi.R
@@ -66,5 +66,3 @@ stata2ddi <- function(filename,
 
   main()
 }
-
-iconv(label1

--- a/R/stata2ddi.R
+++ b/R/stata2ddi.R
@@ -60,7 +60,7 @@ stata2ddi <- function(filename,
       var           = var,
       data          = stata_file[[i]],
       val_labels    = attr(stata_file, "label.table")[[
-                        attr(stata_file, "val.labels")[i] ]],
+        iconv(attr(stata_file, "val.labels")[i], from="", to="UTF-8") ]],
       import_options = import_options)
   }
 

--- a/R/stata2ddi.R
+++ b/R/stata2ddi.R
@@ -34,13 +34,22 @@ stata2ddi <- function(filename,
     code_book
   }
 
+  .encconv <- function(x) {
+    iconv(x, from="", to="UTF-8")
+  }
+  
   .read_stata <- function(filename, is_stata_mis) {
     read_dta <- read.dta(filename,
              convert.factors = FALSE,
              convert.dates   = FALSE,
              missing.type    = is_stata_mis)
-    attr(read_dta, "var.labels") <- iconv(attr(read_dta, "var.labels"),
-                                          from="", to="UTF-8")
+    attr(read_dta, "var.labels") <- .encconv(attr(read_dta, "var.labels"))
+    val.labels <- attr(read_dta, "val.labels")
+    val.labels <- unique(val.labels[val.labels != ""]) 
+    for(x in val.labels){
+      names(attr(read_dta, "label.table")[[x]]) <- 
+        .encconv(names(attr(read_dta, "label.table")[[x]]))
+    }
     read_dta
   }
 

--- a/R/stata2ddi.R
+++ b/R/stata2ddi.R
@@ -35,10 +35,13 @@ stata2ddi <- function(filename,
   }
 
   .read_stata <- function(filename, is_stata_mis) {
-    read.dta(filename,
+    read_dta <- read.dta(filename,
              convert.factors = FALSE,
              convert.dates   = FALSE,
              missing.type    = is_stata_mis)
+    attr(read_dta, "var.labels") <- iconv(attr(read_dta, "var.labels"),
+                                          from="", to="UTF-8")
+    read_dta
   }
 
   .data_dscr <- function(stata_file, import_options) {
@@ -52,15 +55,15 @@ stata2ddi <- function(filename,
 
   .parser <- function(i, stata_file, import_options) {
     var <- ddi_var(id   = attr(stata_file, "names")[i],
-                   labl = iconv(attr(stata_file, "var.labels")[i], from="", to="UTF-8"))
+                   labl = attr(stata_file, "var.labels")[i])
     var$format <- attr(stata_file, "formats")[i]
     var$miss   <- attr(stata_file, "missing")[[i]]
     r2ddi:::ddi_var_dscr_stata(
       i             = i,
       var           = var,
       data          = stata_file[[i]],
-      val_labels    = iconv(attr(stata_file, "label.table")[[
-        attr(stata_file, "val.labels")[i] ]], from="", to="UTF-8"),
+      val_labels    = attr(stata_file, "label.table")[[
+                             attr(stata_file, "val.labels")[i] ]],
       import_options = import_options)
   }
 

--- a/R/stata2ddi.R
+++ b/R/stata2ddi.R
@@ -59,8 +59,8 @@ stata2ddi <- function(filename,
       i             = i,
       var           = var,
       data          = stata_file[[i]],
-      val_labels    = attr(stata_file, "label.table")[[
-        iconv(attr(stata_file, "val.labels")[i], from="", to="UTF-8") ]],
+      val_labels    = iconv(attr(stata_file, "label.table")[[
+        attr(stata_file, "val.labels")[i] ]], from="", to="UTF-8"),
       import_options = import_options)
   }
 

--- a/R/stata2ddi.R
+++ b/R/stata2ddi.R
@@ -52,7 +52,7 @@ stata2ddi <- function(filename,
 
   .parser <- function(i, stata_file, import_options) {
     var <- ddi_var(id   = attr(stata_file, "names")[i],
-                   labl = attr(stata_file, "var.labels")[i])
+                   labl = iconv(attr(stata_file, "var.labels")[i], from="", to="UTF-8"))
     var$format <- attr(stata_file, "formats")[i]
     var$miss   <- attr(stata_file, "missing")[[i]]
     r2ddi:::ddi_var_dscr_stata(
@@ -67,3 +67,4 @@ stata2ddi <- function(filename,
   main()
 }
 
+iconv(label1


### PR DESCRIPTION
Mit dem Vorschlag erscheinen Umlaute in Variable-Labels und Value-Labels auch im XML.